### PR TITLE
Add additionalArgs to maven integration tests method

### DIFF
--- a/vars/mavenIntegrationTestWithExistingNamespace.groovy
+++ b/vars/mavenIntegrationTestWithExistingNamespace.groovy
@@ -9,6 +9,7 @@ def call(body) {
     body()
 
     def utils = new Utils()
+    def args = config.additionalArgs
     def ns = config.environment
     kubeNS = "-Dkubernetes.namespace=${ns} -Dfabric8.use.existing=${ns}"
     echo "Running the integration tests in the namespace: ${ns}"
@@ -16,7 +17,7 @@ def call(body) {
     if (utils.isDisabledITests()) {
         echo "WARNING: Integration tests are current DISABLED for these pipelines!"
     } else {
-        sh "./mvnw org.apache.maven.plugins:maven-failsafe-plugin:2.18.1:integration-test ${kubeNS} -Dit.test=${config.itestPattern} -DfailIfNoTests=${config.failIfNoTests} org.apache.maven.plugins:maven-failsafe-plugin:2.18.1:verify"
+        sh "./mvnw org.apache.maven.plugins:maven-failsafe-plugin:2.18.1:integration-test ${kubeNS} -Dit.test=${config.itestPattern} -DfailIfNoTests=${config.failIfNoTests} ${args} org.apache.maven.plugins:maven-failsafe-plugin:2.18.1:verify"
         junitResults(body);
     }
   }


### PR DESCRIPTION
We needed to add additional arguments while running integration tests, specifically this `spring.profiles.active` for our case. This allows us to pass in additional arguments to integration tests method when necessary